### PR TITLE
Fix installer flow checks

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-set -e
+set -eo pipefail
 
 ######################################################################################
 #                                                                                    #
@@ -100,7 +100,31 @@ execute() {
   fi
 }
 
+execute_arg() {
+  case "$1" in
+  auto | basic)
+    execute "basic"
+    ;;
+  panel | wings | uninstall)
+    execute "$1"
+    ;;
+  both)
+    execute "panel" "wings"
+    ;;
+  *)
+    error "Invalid option '$1'. Expected one of: auto, panel, wings, both, uninstall."
+    exit 1
+    ;;
+  esac
+}
+
 welcome ""
+
+if [[ -n "${1:-}" ]]; then
+  execute_arg "$1"
+  rm -rf /tmp/lib.sh
+  exit 0
+fi
 
 done=false
 while [ "$done" == false ]; do
@@ -132,9 +156,15 @@ while [ "$done" == false ]; do
 
   [ -z "$action" ] && error "Input is required" && continue
 
-  valid_input=("$(for ((i = 0; i <= ${#actions[@]} - 1; i += 1)); do echo "${i}"; done)")
-  [[ ! " ${valid_input[*]} " =~ ${action} ]] && error "Invalid option"
-  [[ " ${valid_input[*]} " =~ ${action} ]] && done=true && IFS=";" read -r i1 i2 <<<"${actions[$action]}" && execute "$i1" "$i2"
+  if [[ ! "$action" =~ ^[0-9]+$ ]] || ((10#$action >= ${#actions[@]})); then
+    error "Invalid option"
+    continue
+  fi
+
+  action=$((10#$action))
+  done=true
+  IFS=";" read -r i1 i2 <<<"${actions[$action]}"
+  execute "$i1" "$i2"
 done
 
 # Remove lib.sh, so next time the script is run the, newest version is downloaded.

--- a/installers/basic.sh
+++ b/installers/basic.sh
@@ -15,17 +15,10 @@ fi
 # Path (export everything that is possible, doesn't matter that it exists already)
 export PATH="$PATH:/bin:/sbin:/usr/bin:/usr/sbin:/usr/local/bin:/usr/local/sbin"
 
-# Operating System
-export OS=""
-export OS_VER_MAJOR=""
-export CPU_ARCHITECTURE=""
-export ARCH=""
-export SUPPORTED=false
-
 # Download URLs
-export PANEL_DL_URL="https://github.com/pelican-dev/panel/releases/latest/download/panel.tar.gz"
-export WINGS_DL_URL="https://github.com/pelican-dev/wings/releases/latest/download/wings_linux_"
-export GIT_REPO_URL="https://raw.githubusercontent.com/Zinidia/Pelinstaller/Production"
+export PANEL_DL_URL="${PANEL_DL_URL:-https://github.com/pelican-dev/panel/releases/latest/download/panel.tar.gz}"
+export WINGS_DL_URL="${WINGS_DL_URL:-${WINGS_DL_BASE_URL:-https://github.com/pelican-dev/wings/releases/latest/download/wings_linux_}}"
+export GIT_REPO_URL="${GIT_REPO_URL:-${GITHUB_URL:-https://raw.githubusercontent.com/Zinidia/Pelinstaller/Production}}"
 
 # Colors
 COLOR_YELLOW='\033[1;33m'

--- a/installers/panel.sh
+++ b/installers/panel.sh
@@ -410,7 +410,14 @@ configure_nginx() {
     ;;
   esac
 
-  if [ "$ASSUME_SSL" == false ] && [ "$CONFIGURE_LETSENCRYPT" == false ]; then
+  if [ "$ASSUME_SSL" == true ] && [ "$CONFIGURE_LETSENCRYPT" == false ]; then
+    if nginx -t; then
+      systemctl restart nginx
+    else
+      warning "Nginx configuration was written but not reloaded. Install the SSL certificate files and restart nginx."
+    fi
+  else
+    nginx -t
     systemctl restart nginx
   fi
 

--- a/installers/uninstall.sh
+++ b/installers/uninstall.sh
@@ -47,10 +47,16 @@ RM_WINGS="${RM_WINGS:-true}"
 rm_panel_files() {
   output "Removing panel files..."
   rm -rf /var/www/pelican /usr/local/bin/composer
-  [ "$OS" != "centos" ] && unlink /etc/nginx/sites-enabled/pelican.conf
-  [ "$OS" != "centos" ] && rm -f /etc/nginx/sites-available/pelican.conf
-  [ "$OS" != "centos" ] && ln -s /etc/nginx/sites-available/default /etc/nginx/sites-enabled/default
-  [ "$OS" == "centos" ] && rm -f /etc/nginx/conf.d/pelican.conf
+  case "$OS" in
+  ubuntu | debian)
+    rm -f /etc/nginx/sites-enabled/pelican.conf
+    rm -f /etc/nginx/sites-available/pelican.conf
+    [ -e /etc/nginx/sites-available/default ] && ln -sf /etc/nginx/sites-available/default /etc/nginx/sites-enabled/default
+    ;;
+  rocky | almalinux)
+    rm -f /etc/nginx/conf.d/pelican.conf
+    ;;
+  esac
   systemctl restart nginx
   success "Removed panel files."
 }
@@ -78,13 +84,13 @@ rm_services() {
   output "Removing services..."
   systemctl disable --now pelican-queue
   rm -rf /etc/systemd/system/pelican-queue.service
-  systemctl disable --now pteroq
+  systemctl disable --now pteroq || true
   rm -rf /etc/systemd/system/pteroq.service
   case "$OS" in
   ubuntu | debian)
     systemctl disable --now redis-server
     ;;
-  centos)
+  rocky | almalinux)
     systemctl disable --now redis
     systemctl disable --now php-fpm
     rm -rf /etc/php-fpm.d/www-pelican.conf

--- a/installers/wings.sh
+++ b/installers/wings.sh
@@ -116,7 +116,7 @@ ptdl_dl() {
   echo "* Downloading Pelican Wings.. "
 
   mkdir -p /etc/pelican /var/run/wings
-  curl -L -o /usr/local/bin/wings "$WINGS_DL_BASE_URL$ARCH"
+  curl -fsSL -o /usr/local/bin/wings "$WINGS_DL_BASE_URL$ARCH"
 
   chmod u+x /usr/local/bin/wings
 
@@ -126,7 +126,7 @@ ptdl_dl() {
 systemd_file() {
   output "Installing systemd service.."
 
-  curl -o /etc/systemd/system/wings.service "$GITHUB_URL"/configs/wings.service
+  curl -fsSL -o /etc/systemd/system/wings.service "$GITHUB_URL"/configs/wings.service
   systemctl daemon-reload
   systemctl enable wings
 
@@ -179,11 +179,11 @@ configure_mysql() {
       sed -i 's/127.0.0.1/0.0.0.0/g' /etc/mysql/mariadb.conf.d/50-server.cnf
       ;;
     rocky | almalinux)
-      sed -ne 's/^#bind-address=0.0.0.0$/bind-address=0.0.0.0/' /etc/my.cnf.d/mariadb-server.cnf
+      sed -i 's/^#bind-address=0.0.0.0$/bind-address=0.0.0.0/' /etc/my.cnf.d/mariadb-server.cnf
       ;;
     esac
 
-    systemctl restart mysqld
+    systemctl restart mariadb
   fi
 
   success "MySQL configured!"

--- a/lib/verify-fqdn.sh
+++ b/lib/verify-fqdn.sh
@@ -95,9 +95,9 @@ dns_verify() {
 
 main() {
   fqdn="$1"
+  confirm || exit 1
   dep_install
-  confirm && dns_verify
-  true
+  dns_verify
 }
 
 main "$1" "$2"

--- a/ui/panel.sh
+++ b/ui/panel.sh
@@ -68,7 +68,7 @@ export CONFIGURE_FIREWALL=false
 # ------------ User input functions ------------ #
 
 ask_letsencrypt() {
-  if [ "$CONFIGURE_UFW" == false ] && [ "$CONFIGURE_FIREWALL_CMD" == false ]; then
+  if [ "$CONFIGURE_FIREWALL" == false ]; then
     warning "Let's Encrypt requires port 80/443 to be opened! You have opted out of the automatic firewall configuration; use this at your own risk (if port 80/443 is closed, the script will fail)!"
   fi
 

--- a/ui/wings.sh
+++ b/ui/wings.sh
@@ -60,7 +60,7 @@ export MYSQL_DBHOST_PASSWORD=""
 # ------------ User input functions ------------ #
 
 ask_letsencrypt() {
-  if [ "$CONFIGURE_UFW" == false ] && [ "$CONFIGURE_FIREWALL_CMD" == false ]; then
+  if [ "$CONFIGURE_FIREWALL" == false ]; then
     warning "Let's Encrypt requires port 80/443 to be opened! You have opted out of the automatic firewall configuration; use this at your own risk (if port 80/443 is closed, the script will fail)!"
   fi
 
@@ -164,7 +164,7 @@ main() {
   ask_letsencrypt
 
   if [ "$CONFIGURE_LETSENCRYPT" == true ]; then
-    while [ -z "$FQDN" ]; do
+    while [ "$CONFIGURE_LETSENCRYPT" == true ] && [ -z "$FQDN" ]; do
       echo -n "* Set the FQDN to use for Let's Encrypt (node.example.com): "
       read -r FQDN
 


### PR DESCRIPTION
﻿## Summary
- make the documented auto installer argument dispatch to the basic install flow
- tighten menu input, DNS verification consent, and HTTPS prompt handling
- fix several supported distro paths for Wings and uninstall flows

## Why
The installer had a few control-flow paths where invalid input, failed child scripts, or unsupported service names could either abort unexpectedly or continue as if the operation succeeded.

## Details
- preserve detected OS and architecture in the basic installer
- fail fast when Wings binary or systemd unit downloads fail
- restart nginx after writing panel config when the config is valid
- use Rocky and AlmaLinux service and nginx paths during uninstall

## Validation
- ran bash syntax checks for every tracked shell script
- ran git diff whitespace checks
